### PR TITLE
Add dom accessor for View

### DIFF
--- a/src/editor.ml
+++ b/src/editor.ml
@@ -82,6 +82,8 @@ module View = struct
     include (Jv.Id : Jv.CONV with type t := t)
   end
 
+  let dom t = Jv.get t "dom" |> Brr.El.of_jv
+
   let update_listener _ : (Update.t -> unit, Jv.t) State.facet =
     let module F = State.FacetMaker (Func(Update)) in
     let jv = Jv.get g "updateListener" in 

--- a/src/editor.mli
+++ b/src/editor.mli
@@ -67,6 +67,8 @@ module View : sig
     include Jv.CONV with type t := t
   end
 
+  val dom : t -> Brr.El.t
+
   val update_listener : unit -> (Update.t -> unit, Jv.t) State.facet
 
   val line_wrapping : unit -> Extension.t


### PR DESCRIPTION
This allows it to be added to other `Brr.El.t` elements before putting into the actual page.