### PR TITLE
More bindings

### DIFF
--- a/src/autocomplete/autocomplete.ml
+++ b/src/autocomplete/autocomplete.ml
@@ -21,7 +21,7 @@ module Completion = struct
     set_if_some_string o "info" info;
     Jv.set_if_some o "apply" apply;
     set_if_some_string o "type" type_;
-    Jv.Int.set_if_some o "boost" boost; 
+    Jv.Int.set_if_some o "boost" boost;
     o
 
 end
@@ -32,6 +32,12 @@ module Context = struct
 
   include (Jv.Id : Jv.CONV with type t := t)
 
+  let state t = Jv.get t "state" |> Editor.State.of_jv
+
+  let pos t = Jv.Int.get t "pos"
+
+  let explicit t = Jv.Bool.get t "explicit"
+
   let token_before t types =
     let jv = Jv.call t "tokenBefore" [| Jv.of_list Jv.of_string types |] in
     if Jv.is_none jv then None else Some jv
@@ -39,6 +45,8 @@ module Context = struct
   let match_before t regex =
     let jv = Jv.call t "matchBefore" [| RegExp.to_jv regex |] in
     if Jv.is_none jv then None else Some jv
+
+  let aborted t = Jv.Bool.get t "aborted"
 end
 
 module Result = struct
@@ -57,19 +65,27 @@ module Result = struct
     o
 end
 
-type source = Context.t -> Result.t option Fut.t
-(** A completion source *)
+module Source = struct
+  type t = Jv.t
 
-let source_to_jv (src : source) = 
-  let f ctx =
-    let fut = Fut.map (fun v -> Ok v) @@ src (Context.of_jv ctx) in
-    Fut.to_promise ~ok:(fun t -> Option.value ~default:Jv.null (Option.map Result.to_jv t)) fut
-  in
+  include (Jv.Id : Jv.CONV with type t := t)
+
+  let create (src : Context.t -> Result.t option Fut.t) =
+    let f ctx =
+      let fut = Fut.map (fun v -> Ok v) @@ src (Context.of_jv ctx) in
+      Fut.to_promise fut
+        ~ok:(fun t ->
+          Option.value ~default:Jv.null (Option.map Result.to_jv t))
+    in
     Jv.repr f
+
+  let from_list (l : Completion.t list) =
+    Jv.call autocomplete "completeFromList" [| Jv.of_jv_list l |] |> of_jv
+end
 
 type config = Jv.t
 
-let config 
+let config
   ?activate_on_typing
   ?override
   ?max_rendered_options
@@ -81,7 +97,7 @@ let config
   () =
   let o = Jv.obj [||] in
    Jv.Bool.set_if_some o "activateOnTyping" activate_on_typing;
-   Jv.set_if_some o "override" (Option.map (fun v -> Jv.of_list source_to_jv v) override);
+   Jv.set_if_some o "override" (Option.map (fun v -> Jv.of_jv_list v) override);
    Jv.Int.set_if_some o "maxRenderedOptions" max_rendered_options;
    Jv.Bool.set_if_some o "defaultKeyMap" default_key_map;
    Jv.Bool.set_if_some o "aboveCursor" above_cursor;

--- a/src/autocomplete/autocomplete.ml
+++ b/src/autocomplete/autocomplete.ml
@@ -112,7 +112,7 @@ let create ?(config = Jv.null) () =
 
 (* type status = Active | Pending
 
-let status state = 
+let status state =
 
 val status : Editor.State.t -> status option
 (** Gets the current completion status *)
@@ -122,4 +122,3 @@ val current_completions : Editor.State.t -> Completion.t list
 
 val selected_completion : Editor.State.t -> Completion.t option
 * Returh the currently selected completion if any *)
-

--- a/src/autocomplete/autocomplete.mli
+++ b/src/autocomplete/autocomplete.mli
@@ -1,26 +1,49 @@
 open Code_mirror
 
+(** Most of this documention originate from the code-mirror reference.
+
+  {{:https://codemirror.net/6/docs/ref/#autocomplete} Visit the
+  reference directly for additional information.}  *)
+
 val autocomplete : Jv.t
 (** Global autocomplete value *)
 
 module RegExp = RegExp
 
 module Completion : sig
+  (** Represents individual completions. *)
+
   type t
+  (** Completion *)
 
   include Jv.CONV with type t := t
 
   val create :
     label:string ->
     ?detail:string ->
-    ?info:string -> 
+    ?info:string ->
     ?apply:t ->
     ?type_:string ->
     ?boost:int ->
     unit -> t
+  (** Creates a completion.
+
+    @param label The label to show in the completion picker.
+    @param detail An optional short piece of information to show after the
+    label.
+    @param info Additional info to show when the completion is selected.
+    @param apply (todo) How to apply the completion.
+    @param type     The type of the completion. This is used to pick an icon to
+    show for the completion.
+    @param boost
+
+    {{:https://codemirror.net/6/docs/ref/#autocomplete.Completion} See the
+    reference for additional information.} *)
 end
 
 module Context : sig
+  (** An instance of this is passed to completion source functions. *)
+
   type t
   (** Completion context *)
 
@@ -39,8 +62,11 @@ module Context : sig
     is true. *)
 
   val token_before : t -> string list -> Jv.t option
+  (** Get the extent, content, and (if there is a token) type of the token
+    before this.pos. *)
 
   val match_before : t -> RegExp.t -> Jv.t option
+  (** Get the match of the given expression directly before the cursor. *)
 
   val aborted : t -> bool
   (** Yields true when the query has been aborted. Can be useful in
@@ -48,6 +74,8 @@ module Context : sig
 end
 
 module Result : sig
+  (** Objects returned by completion sources. *)
+
   type t
   (** Completion result *)
 
@@ -60,18 +88,31 @@ module Result : sig
     ?span:RegExp.t ->
     ?filter:bool ->
     unit -> t
-  (** Creating a new completion result (see {{: https://codemirror.net/6/docs/ref/#autocomplete.CompletionResult} the docs}).*)
+  (** Creating a new completion result (see {{: https://codemirror.net/6/docs/ref/#autocomplete.CompletionResult} the docs}).
+    @param from The start of the range that is being completed.
+    @param to_ The end of the range that is being completed. Defaults to the
+      main cursor position.
+    @param options The completions returned.
+    @param span When given, further input that causes the part of the document
+      between [from] and [to_] to match this regular expression will not query
+      the completion source again
+    @param filter By default, the library filters and scores completions. Set
+      filter to false to disable this, and cause your completions to all be
+      included, in the order they were given.
+  *)
 end
 
 module Source : sig
   type t
-  (** A Completion source *)
+  (** Completion source *)
 
   include Jv.CONV with type t := t
 
   val create : (Context.t -> Result.t option Fut.t) -> t
 
   val from_list : Completion.t list -> t
+  (** Given a a fixed array of options, return an autocompleter that completes
+    them. *)
 end
 
 type config

--- a/src/autocomplete/autocomplete.mli
+++ b/src/autocomplete/autocomplete.mli
@@ -1,3 +1,5 @@
+open Code_mirror
+
 val autocomplete : Jv.t
 (** Global autocomplete value *)
 
@@ -24,9 +26,25 @@ module Context : sig
 
   include Jv.CONV with type t := t
 
+  val state : t -> Editor.State.t
+  (** The editor state that the completion happens in. *)
+
+  val pos : t -> int
+  (** The position at which the completion is happening. *)
+
+  val explicit : t -> bool
+  (** Indicates whether completion was activated explicitly, or implicitly by
+    typing. The usual way to respond to this is to only return completions when
+    either there is part of a completable entity before the cursor, or explicit
+    is true. *)
+
   val token_before : t -> string list -> Jv.t option
 
   val match_before : t -> RegExp.t -> Jv.t option
+
+  val aborted : t -> bool
+  (** Yields true when the query has been aborted. Can be useful in
+    asynchronous queries to avoid doing work that will be ignored. *)
 end
 
 module Result : sig
@@ -45,15 +63,22 @@ module Result : sig
   (** Creating a new completion result (see {{: https://codemirror.net/6/docs/ref/#autocomplete.CompletionResult} the docs}).*)
 end
 
-type source = Context.t -> Result.t option Fut.t
-(** A completion source *)
+module Source : sig
+  type t
+  (** A Completion source *)
 
+  include Jv.CONV with type t := t
+
+  val create : (Context.t -> Result.t option Fut.t) -> t
+
+  val from_list : Completion.t list -> t
+end
 
 type config
 
-val config : 
-  ?activate_on_typing:bool -> 
-  ?override:source list ->
+val config :
+  ?activate_on_typing:bool ->
+  ?override:Source.t list ->
   ?max_rendered_options:int ->
   ?default_key_map:bool ->
   ?above_cursor:bool ->


### PR DESCRIPTION
Hello @patricoferris ! As you may know I am working on a version of Merlin that is built for the web and integrates with code-mirror.

In the objective of integrating with the playground I am now moving my very ad-hoc and dirty javascript code to your code-mirror jsoo bindings. And of course I am missing things :-)

This PR:
- Adds some missing autocomplete bindings
- Add documentation to the autocomplete module

I chose to make a submodule `Source` for the `CompletionSource` even if it is not an "interface" because I felt it makes more sense like this (but it is a breaking change).
I also tried to add parameters description in the doc comments, not sure if that is a good idea or not, but it looks useful at first sight.

Finally I think we should copy-paste a lot of the short docstrings from the reference to ease the use of the bindings, but I am not sure of the legality of the process. I think it is ok since the doc is [part of the source](https://github.com/codemirror/autocomplete/blob/main/src/completion.ts) which is under the MIT licence (and it is not a "substantial portion of the Software"). @tmattio ?